### PR TITLE
Update config.py to override default limit of 100 assets in the GET request

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -68,7 +68,7 @@ class Config(metaclass=Singleton):
             'submission_url': f'{api_v1}/submissions',
             'forms_url': f'{api_v1}/forms',
             'headers': {'Authorization': f"Token {data['token']}"},
-            'params': {'format': 'json'},
+            'params': {'format': 'json', 'limit': '999999999'},
             'deployment_url': f'{asset_url}/deployment/',
             'xml_url': f'{asset_url}/data.xml',
             'data_url': f'{asset_url}/data',


### PR DESCRIPTION
![image](https://github.com/kobotoolbox/kobo-transfer/assets/78334846/9db4778f-6cd7-4297-8ef3-3377b81f6437)

Before adding the param `limit`, the script resulting in error of not found the asset with the corresponding `uid`.