### PR TITLE
Add trailing slash to resolve 500 error when creating form media files

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -82,7 +82,7 @@ class Config(metaclass=Singleton):
             'deployment_url': f'{asset_url}/deployment/',
             'xml_url': f'{asset_url}/data.xml',
             'data_url': f'{asset_url}/data',
-            'files_url': f'{asset_url}/files',
+            'files_url': f'{asset_url}/files/',
             'validation_statuses_url': f'{asset_url}/data/validation_statuses.json',
             'advanced_submission_url': f"{data['kf_url']}/advanced_submission_post/{data['asset_uid']}",
         }


### PR DESCRIPTION
Text of error from server (the Django development server, in this case) was:

    RuntimeError: You called this URL via POST, but the URL doesn't end
    in a slash and you have APPEND_SLASH set. Django can't redirect to
    the slash URL while maintaining POST data. Change your form to point
    to kf.local.kbtdev.org/api/v2/assets/aGMgPJfYH6YCNyKEAxNyVW/files/
    (note the trailing slash), or set APPEND_SLASH=False in your Django
    settings.