### PR TITLE
refactor: migrate from KoboCAT API v1 to OpenRosa and KPI v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE
+.idea
+
+# LLM Agent
+.claude

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -64,24 +64,21 @@ class Config(metaclass=Singleton):
 
     @staticmethod
     def _append_additional_config_data(data):
-        api_v1 = f"{data['kc_url']}/api/v1"
         api_v2 = f"{data['kf_url']}/api/v2"
-        assets_url = f'{api_v2}/assets'
+        assets_url = f'{api_v2}/assets/'
         asset_url = f"{api_v2}/assets/{data['asset_uid']}"
         return {
             **data,
-            'api_v1': api_v1,
-            'api_v2': api_v2,
+            'api_v2': f'{api_v2}/',
             'assets_url': assets_url,
-            'asset_url': asset_url,
-            'asset_url_json': f'{asset_url}.json',
-            'submission_url': f'{api_v1}/submissions',
-            'forms_url': f'{api_v1}/forms',
+            'asset_url': f'{asset_url}/',
+            'asset_url_json': f"{asset_url}.json",
+            'submission_url': f"{data['kc_url']}/submission",
             'headers': {'Authorization': f"Token {data['token']}"},
             'params': {'format': 'json'},
             'deployment_url': f'{asset_url}/deployment/',
             'xml_url': f'{asset_url}/data.xml',
-            'data_url': f'{asset_url}/data',
+            'data_url': f'{asset_url}/data/',
             'files_url': f'{asset_url}/files/',
             'validation_statuses_url': f'{asset_url}/data/validation_statuses.json',
             'advanced_submission_url': f"{data['kf_url']}/advanced_submission_post/{data['asset_uid']}",
@@ -111,12 +108,6 @@ class Config(metaclass=Singleton):
             )
             if kf_res.status_code != 200:
                 invalid(f'⚠️ Invalid token for `{loc}`.')
-            kc_res = requests.get(
-                url=config['api_v1'], headers=config['headers']
-            )
-            if kc_res.status_code != 200:
-                invalid(f'⚠️ Invalid `kc_url` for `{loc}`.')
-
             if not (loc == 'dest' and self.dest_without_asset_uid):
                 kf_res = requests.get(
                     url=config['asset_url'],

--- a/transfer/asset.py
+++ b/transfer/asset.py
@@ -34,7 +34,7 @@ def create_asset(config_dest, asset_setup_content):
     Create the `dest` asset, initially without content.
     '''
     res = requests.post(
-        url=config_dest['assets_url'] + '/',
+        url=config_dest['assets_url'],
         headers=config_dest['headers'],
         params=config_dest['params'],
         json=asset_setup_content,
@@ -60,7 +60,7 @@ def deploy_all_versions(config_src, config_dest, deployed_versions):
 
         # Patch this content to the `dest asset`
         res = requests.patch(
-            url=config_dest['asset_url'] + '/',
+            url=config_dest['asset_url'],
             headers=config_dest['headers'],
             params=config_dest['params'],
             json={"content": json.dumps(asset_content)},

--- a/transfer/media.py
+++ b/transfer/media.py
@@ -115,7 +115,7 @@ def get_clean_stats():
 
 
 def get_data_url(asset_uid, kf_url):
-    return f'{kf_url}/api/v2/assets/{asset_uid}/data'
+    return f'{kf_url}/api/v2/assets/{asset_uid}/data/'
 
 
 def get_filename(path):

--- a/transfer/xml.py
+++ b/transfer/xml.py
@@ -180,17 +180,13 @@ def log_failure(_uuid):
 def get_formhub_uuid():
     config = Config().dest
     res = requests.get(
-        url=config['forms_url'],
+        url=config['asset_url'],
         headers=config['headers'],
         params=config['params'],
     )
     if not res.status_code == 200:
         raise Exception('Something went wrong')
-    all_forms = res.json()
-    latest_form = [
-        f for f in all_forms if f['id_string'] == config['asset_uid']
-    ][0]
-    return latest_form['uuid']
+    return res.json()['deployment__uuid']
 
 
 def get_deployed_versions():


### PR DESCRIPTION
## Summary
Submission URLs were pointing to the deprecated KoboCAT API v1, causing failures as that API is phased out.

## Notes
- `submission_url`: `{kc_url}/api/v1/submissions` → `{kc_url}/submission` (OpenRosa endpoint)
- `get_formhub_uuid()`: was fetching from `{kc_url}/api/v1/forms`; now uses `GET /api/v2/assets/{uid}/` and reads `deployment__uuid`
- Removed `api_v1` and `forms_url` keys from config; removed the KC URL validation step in `_validate_config()`
- Added trailing slashes to all KPI v2 URLs (`api_v2`, `assets_url`, `asset_url`, `data_url`) to avoid 302 redirects
- Removed manual `+ '/'` concatenations in `transfer/asset.py` that are now redundant
- `advanced_submission_post` endpoint (used for analysis data) is also outdated but will be addressed in a separate PR

## Preview steps
Run a transfer against a live environment and confirm submissions are accepted (201/202) and the formhub UUID is correctly resolved.