### PR TITLE
feat: support new supplement API format for analysis sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ the tree structure of:
   longer unique, and therefore won't be rejected from the `dest` project. This
   will be addressed once transferred submissions have their `__version__` value
   matching the new version UIDs at the `dest` project.
+- When syncing analysis data (`--analysis-data`), automatic actions
+  (`automatic_google_transcription`, `automatic_google_translation`,
+  `automatic_bedrock_qual`) are converted to their manual equivalents on the
+  destination. The original automatic processing is not reproduced, and internal
+  version UUIDs will differ from the source.
 - Due to a known KoboToolbox issue, projects may contain submissions with
   duplicate submission UUIDs. Some of these submissions may be full duplicates
   of themselves, while others are unique submissions but contain a duplicate

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -81,7 +81,6 @@ class Config(metaclass=Singleton):
             'data_url': f'{asset_url}/data/',
             'files_url': f'{asset_url}/files/',
             'validation_statuses_url': f'{asset_url}/data/validation_statuses.json',
-            'advanced_submission_url': f"{data['kf_url']}/advanced_submission_post/{data['asset_uid']}",
         }
 
     def _validate_config(self):

--- a/run.py
+++ b/run.py
@@ -18,6 +18,23 @@ from transfer.xml import (
 from transfer.validation_status import sync_validation_statuses
 
 
+def _confirm_analysis_data_sync():
+    print(
+        '\n⚠️  Warning: Analysis data sync has the following limitations:\n'
+        '  - Automatic actions (transcription, translation, Bedrock qualitative\n'
+        '    analysis) are converted to their manual equivalents on dest. The\n'
+        '    original automatic processing is not reproduced.\n'
+        '  - Internal version UUIDs will differ from the source.\n'
+    )
+    while True:
+        answer = input('Proceed? [y/n]: ').strip().lower()
+        if answer == 'y':
+            break
+        if answer == 'n':
+            print('Cancelled. Re-run without the --analysis-data (-ad) flag to skip.')
+            sys.exit()
+
+
 def get_uuids(config_loc, params):
     def get_uuids_rec(uuids=[], url=None, params=None, headers=None):
         if 'fields' not in url:
@@ -104,6 +121,7 @@ def main(
         sys.exit()
 
     if analysis_data and not sync:
+        _confirm_analysis_data_sync()
         print('📶 Syncing analysis data')
         sync_analysis_data(config, limit)
         sys.exit()
@@ -163,6 +181,7 @@ def main(
             sync_validation_statuses(config, chunk_size, limit)
 
         if analysis_data:
+            _confirm_analysis_data_sync()
             print('📶 Syncing analysis data')
             sync_analysis_data(config, limit)
 

--- a/transfer/analysis.py
+++ b/transfer/analysis.py
@@ -1,59 +1,191 @@
+import re
 import requests
 
 
-def clean_sup_details(input_dict):
-    output_dict = {}
-    for key, value in input_dict.items():
-        if isinstance(value, dict):
-            cleaned_value = clean_sup_details(value)
-            if cleaned_value:  # Only add non-empty dictionaries
-                output_dict[key] = cleaned_value
-        elif isinstance(value, list):
-            cleaned_list = [
-                clean_sup_details(item) if isinstance(item, dict) else item
-                for item in value
+ACTION_NAME_MAP = {
+    'automatic_google_transcription': 'manual_transcription',
+    'automatic_google_translation': 'manual_translation',
+    'automatic_bedrock_qual': 'manual_qual',
+}
+
+_UUID_RE = re.compile(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+)
+
+
+def _is_uuid(key):
+    return bool(_UUID_RE.match(key))
+
+
+def _get_versions_data(versions):
+    """
+    Return _data for all versions in chronological order (oldest first).
+    Strips `status` since manual actions don't accept it.
+    """
+    sorted_v = sorted(versions, key=lambda v: v.get('_dateCreated', ''))
+    return [
+        {k: val for k, val in v.get('_data', {}).items() if k != 'status'}
+        for v in sorted_v
+        if v.get('_data')
+    ]
+
+
+def clean_sup_details(data):
+    """
+    Transform GET /supplement/ response into an ordered list of PATCH payloads.
+
+    Each version becomes its own payload to preserve full history.
+    Ordering: transcription first (translation depends on it), then
+    translation, then qual (no dependencies).
+    Automatic action names are mapped to their manual equivalents.
+    """
+    version = data.get('_version')
+    transcription_payloads = []
+    translation_payloads = []
+    qual_payloads = []
+
+    for question_xpath, actions in data.items():
+        if question_xpath.startswith('_') or not isinstance(actions, dict):
+            continue
+
+        for action_key, action_value in actions.items():
+            if action_key.startswith('_') or not isinstance(action_value, dict):
+                continue
+
+            mapped_action = ACTION_NAME_MAP.get(action_key, action_key)
+
+            if '_versions' in action_value:
+                # Direct action (e.g. transcription)
+                for v_data in _get_versions_data(action_value['_versions']):
+                    transcription_payloads.append({
+                        '_version': version,
+                        question_xpath: {mapped_action: v_data},
+                    })
+            else:
+                # Sub-keyed action: language codes (translation) or UUIDs (qual)
+                for sub_key, sub_value in action_value.items():
+                    if sub_key.startswith('_') or not isinstance(sub_value, dict):
+                        continue
+                    if '_versions' not in sub_value:
+                        continue
+
+                    for v_data in _get_versions_data(sub_value['_versions']):
+                        payload = {
+                            '_version': version,
+                            question_xpath: {mapped_action: v_data},
+                        }
+                        if _is_uuid(sub_key):
+                            qual_payloads.append(payload)
+                        else:
+                            translation_payloads.append(payload)
+
+    return transcription_payloads + translation_payloads + qual_payloads
+
+
+def sync_advanced_features(config_src, config_dest):
+    """
+    Configure dest advanced features from src.
+    Maps automatic actions to manual equivalents and merges params when
+    multiple src features map to the same dest action.
+    """
+    src_res = requests.get(
+        url=config_src['asset_url'] + 'advanced-features/',
+        headers=config_src['headers'],
+    )
+    src_res.raise_for_status()
+
+    dest_res = requests.get(
+        url=config_dest['asset_url'] + 'advanced-features/',
+        headers=config_dest['headers'],
+    )
+    dest_res.raise_for_status()
+    existing_on_dest = {
+        (f['question_xpath'], f['action']) for f in dest_res.json()
+    }
+
+    dest_features = {
+        (f['question_xpath'], f['action']): f for f in dest_res.json()
+    }
+
+    to_create = {}
+    to_update = {}  # key → (dest_uid, merged_params)
+
+    for f in src_res.json():
+        action = f.get('action', '')
+        mapped_action = ACTION_NAME_MAP.get(action, action)
+        key = (f['question_xpath'], mapped_action)
+
+        target = to_create if key not in dest_features else None
+
+        if target is None:
+            # Feature exists on dest — check for missing params
+            dest_feature = dest_features[key]
+            dest_ids = {
+                p.get('language') or p.get('uuid')
+                for p in dest_feature.get('params', [])
+            }
+            missing = [
+                p for p in f.get('params', [])
+                if (p.get('language') or p.get('uuid')) not in dest_ids
             ]
-            cleaned_list = [
-                item for item in cleaned_list if item
-            ]  # Remove empty dictionaries from the list
-            if cleaned_list:  # Only add non-empty lists
-                output_dict[key] = cleaned_list
+            if missing:
+                if key not in to_update:
+                    to_update[key] = (
+                        dest_feature['uid'],
+                        list(dest_feature.get('params', [])),
+                    )
+                existing_ids = {
+                    p.get('language') or p.get('uuid')
+                    for p in to_update[key][1]
+                }
+                for p in missing:
+                    pid = p.get('language') or p.get('uuid')
+                    if pid not in existing_ids:
+                        to_update[key][1].append(p)
+                        existing_ids.add(pid)
         else:
-            if key in ['uuid', 'type', 'val', 'value', 'languageCode']:
-                output_dict[key] = value
+            if key not in target:
+                target[key] = {
+                    'question_xpath': f['question_xpath'],
+                    'action': mapped_action,
+                    'params': list(f.get('params', [])),
+                }
+            else:
+                existing_ids = {
+                    p.get('language') or p.get('uuid')
+                    for p in target[key]['params']
+                }
+                for p in f.get('params', []):
+                    pid = p.get('language') or p.get('uuid')
+                    if pid not in existing_ids:
+                        target[key]['params'].append(p)
+                        existing_ids.add(pid)
 
-    if 'type' in output_dict and 'val' in output_dict:
-        if output_dict['type'] == 'qual_select_multiple':
-            output_dict['val'] = [
-                item['uuid'] for item in output_dict['val'] if 'uuid' in item
-            ]
+    for feature in to_create.values():
+        res = requests.post(
+            url=config_dest['asset_url'] + 'advanced-features/',
+            headers=config_dest['headers'],
+            json=feature,
+        )
+        res.raise_for_status()
+        print(f"✅ {feature['action']} ({feature['question_xpath']})")
 
-        if output_dict['type'] == 'qual_select_one':
-            output_dict['val'] = output_dict['val']['uuid']
-
-    return output_dict
+    for (question_xpath, action), (dest_uid, merged_params) in to_update.items():
+        res = requests.patch(
+            url=config_dest['asset_url'] + f'advanced-features/{dest_uid}/',
+            headers=config_dest['headers'],
+            json={'params': merged_params},
+        )
+        res.raise_for_status()
+        print(f"✅ updated {action} ({question_xpath})")
 
 
 def sync_analysis_data(config, limit=10000):
     config_src = config.src
     config_dest = config.dest
 
-    adv_features_res = requests.get(
-        url=config_src['asset_url'],
-        headers=config_src['headers'],
-        params=config_src['params'],
-    )
-    adv_features_res.raise_for_status()
-    adv_features = adv_features_res.json()['advanced_features']
-
-    adv_features_payload = {'advanced_features': adv_features}
-    print('📋 Creating analysis form in dest project')
-    adv_features_patch_res = requests.patch(
-        url=config_dest['asset_url_json'],
-        headers=config_dest['headers'],
-        json=adv_features_payload,
-    )
-    adv_features_patch_res.raise_for_status()
+    print('📋 Configuring analysis features in dest project')
+    sync_advanced_features(config_src, config_dest)
 
     def sync_rec(url):
         sub_res = requests.get(
@@ -68,22 +200,31 @@ def sync_analysis_data(config, limit=10000):
 
         for submission in submissions:
             uuid = submission['_uuid']
-            sup_details = submission.get('_supplementalDetails')
 
-            if not sup_details:
+            sup_res = requests.get(
+                url=f"{config_src['data_url']}{uuid}/supplement/",
+                headers=config_src['headers'],
+            )
+            if not sup_res.ok:
                 continue
 
-            sd_payload = {'submission': uuid, **clean_sup_details(sup_details)}
-            sd_post_res = requests.post(
-                url=config_dest['advanced_submission_url'],
-                headers=config_dest['headers'],
-                json=sd_payload,
-            )
-            try:
-                sd_post_res.raise_for_status()
+            payloads = clean_sup_details(sup_res.json())
+            if not payloads:
+                continue
+
+            failed = False
+            for payload in payloads:
+                sd_post_res = requests.patch(
+                    url=f"{config_dest['data_url']}{uuid}/supplement/",
+                    headers=config_dest['headers'],
+                    json=payload,
+                )
+                if not sd_post_res.ok:
+                    print(f'❌ {uuid} ({sd_post_res.status_code}): {sd_post_res.text}')
+                    failed = True
+                    break
+            if not failed:
                 print(f'✅ {uuid} (Analysis data)')
-            except:
-                print(f'Something went wrong with {uuid}')
 
         if next_:
             sync_rec(next_)


### PR DESCRIPTION
## Summary

Analysis data sync (`--analysis-data`) was broken due to use of deprecated APIs that no longer exist.

## ⚠️ Breaking change

Both source and destination instances must be running **v2.026.12 or later**.

## Notes

**Analysis data sync rewrite (`transfer/analysis.py`):**
- Replaced `advanced_submission_post` endpoint with `/api/v2/assets/{uid}/data/{uuid}/supplement/` (GET + PATCH)
- `sync_advanced_features()` now uses `/advanced-features/` endpoint (POST to create, PATCH to update existing with missing params) instead of patching `advanced_features` on the asset JSON
- `clean_sup_details()` builds ordered PATCH payloads from the supplement response: transcription first (translation depends on it), then translation, then qual
- `ACTION_NAME_MAP` converts automatic actions to manual equivalents (`automatic_google_transcription` → `manual_transcription`, `automatic_google_translation` → `manual_translation`, `automatic_bedrock_qual` → `manual_qual`)
- `status` field is stripped from all payloads (manual actions reject it)
- Each version in `_versions` becomes its own PATCH to preserve full history (oldest first)
- UUID sub-keys vs language-code sub-keys are distinguished by regex to route qual vs translation payloads

**Confirmation prompt (`run.py`):**
- `--analysis-data` now shows a warning and requires `y/n` confirmation before proceeding, covering the automatic→manual conversion limitation and UUID drift

## Preview steps

- Run with `--analysis-data` flag and confirm the prompt appears
- Verify transcription, translation, and qual data transfers correctly to dest